### PR TITLE
Fix OpenGL build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(GL)
         target_link_libraries(acidwarp glew32 opengl32)
     else(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         find_package(OpenGL REQUIRED)
-        target_link_libraries(acidwarp ${OPENGL_gl_LIBRARY})
+        target_link_libraries(acidwarp OpenGL::OpenGL)
     endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 endif(GL)
 


### PR DESCRIPTION
Without this fix, getting errors like this (Ubuntu 25.04 / x86_64)

```
/usr/bin/ld: CMakeFiles/acidwarp.dir/display.c.o: in function `disp_setPalette':
display.c:(.text+0xe5): undefined reference to `glActiveTexture'
/usr/bin/ld: display.c:(.text+0xf7): undefined reference to `glBindTexture'
/usr/bin/ld: display.c:(.text+0x132): undefined reference to `glTexSubImage2D'
/usr/bin/ld: display.c:(.text+0x140): undefined reference to `glClear'
/usr/bin/ld: display.c:(.text+0x154): undefined reference to `glDrawArrays'

```